### PR TITLE
v5.0.5: reload_connections fix

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -16,7 +16,7 @@ module Elasticsearch
         attr_reader   :hosts, :options, :connections, :counter, :last_request_at, :protocol
         attr_accessor :serializer, :sniffer, :logger, :tracer,
                       :reload_connections, :reload_after,
-                      :resurrect_after, :max_retries
+                      :resurrect_after
 
         # Creates a new transport object
         #
@@ -52,7 +52,6 @@ module Elasticsearch
           @reload_connections = options[:reload_connections]
           @reload_after    = options[:reload_connections].is_a?(Integer) ? options[:reload_connections] : DEFAULT_RELOAD_AFTER
           @resurrect_after = options[:resurrect_after] || DEFAULT_RESURRECT_AFTER
-          @max_retries     = options[:retry_on_failure].is_a?(Integer)   ? options[:retry_on_failure]   : DEFAULT_MAX_RETRIES
           @retry_on_status = Array(options[:retry_on_status]).map { |d| d.to_i }
         end
 
@@ -240,10 +239,17 @@ module Elasticsearch
         # @raise  [ServerError]   If request failed on server
         # @raise  [Error]         If no connection is available
         #
-        def perform_request(method, path, params={}, body=nil, &block)
+        def perform_request(method, path, params={}, body=nil, opts={}, &block)
           raise NoMethodError, "Implement this method in your transport class" unless block_given?
           start = Time.now if logger || tracer
           tries = 0
+          reload_on_failure = opts.fetch(:reload_on_failure, @options[:reload_on_failure])
+
+          max_retries = if opts.key?(:retry_on_failure)
+            opts[:retry_on_failure] === true ? DEFAULT_MAX_RETRIES : opts[:retry_on_failure]
+          elsif options.key?(:retry_on_failure)
+            options[:retry_on_failure] === true ? DEFAULT_MAX_RETRIES : options[:retry_on_failure]
+          end
 
           params = params.clone
 
@@ -267,9 +273,9 @@ module Elasticsearch
             __raise_transport_error(response) if response.status.to_i >= 300 && @retry_on_status.include?(response.status.to_i)
 
           rescue Elasticsearch::Transport::Transport::ServerError => e
-            if @retry_on_status.include?(response.status)
+            if response && @retry_on_status.include?(response.status)
               logger.warn "[#{e.class}] Attempt #{tries} to get response from #{url}" if logger
-              if tries <= max_retries
+              if tries <= (max_retries || DEFAULT_MAX_RETRIES)
                 retry
               else
                 logger.fatal "[#{e.class}] Cannot get response from #{url} after #{tries} tries" if logger
@@ -284,12 +290,12 @@ module Elasticsearch
 
             connection.dead!
 
-            if @options[:reload_on_failure] and tries < connections.all.size
+            if reload_on_failure and tries < connections.all.size
               logger.warn "[#{e.class}] Reloading connections (attempt #{tries} of #{connections.all.size})" if logger
               reload_connections! and retry
             end
 
-            if @options[:retry_on_failure]
+            if max_retries
               logger.warn "[#{e.class}] Attempt #{tries} connecting to #{connection.host.inspect}" if logger
               if tries <= max_retries
                 retry

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
@@ -15,7 +15,7 @@ module Elasticsearch
           # @return [Response]
           # @see    Transport::Base#perform_request
           #
-          def perform_request(method, path, params={}, body=nil)
+          def perform_request(method, path, params={}, body=nil, opts={})
             super do |connection,url|
               connection.connection.url = url
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
@@ -16,7 +16,7 @@ module Elasticsearch
           # @return [Response]
           # @see    Transport::Base#perform_request
           #
-          def perform_request(method, path, params={}, body=nil)
+          def perform_request(method, path, params={}, body=nil, opts={})
             super do |connection, url|
               headers = connection.connection.headers
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
@@ -63,7 +63,7 @@ module Elasticsearch
           # @return [Response]
           # @see    Transport::Base#perform_request
           #
-          def perform_request(method, path, params={}, body=nil)
+          def perform_request(method, path, params={}, body=nil, opts={})
             super do |connection, url|
               params[:body] = __convert_to_json(body) if body
               params = params.merge @request_options

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/sniffer.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/sniffer.rb
@@ -28,7 +28,8 @@ module Elasticsearch
         #
         def hosts
           Timeout::timeout(timeout, SnifferTimeoutError) do
-            nodes = transport.perform_request('GET', '_nodes/http').body
+            nodes = transport.perform_request('GET', '_nodes/http', {}, nil, nil,
+                                              reload_on_failure: false).body
 
             hosts = nodes['nodes'].map do |id,info|
               if info[PROTOCOL]

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/sniffer.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/sniffer.rb
@@ -28,7 +28,7 @@ module Elasticsearch
         #
         def hosts
           Timeout::timeout(timeout, SnifferTimeoutError) do
-            nodes = transport.perform_request('GET', '_nodes/http', {}, nil, nil,
+            nodes = transport.perform_request('GET', '_nodes/http', {}, nil,
                                               reload_on_failure: false).body
 
             hosts = nodes['nodes'].map do |id,info|

--- a/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
@@ -121,7 +121,7 @@ describe Elasticsearch::Transport::Transport::Base do
 
       it 'uses the option `retry_on_failure` value' do
         expect {
-          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+          client.transport.perform_request('GET', '/info', {}, nil, retry_on_failure: 5)
         }.to raise_exception(Faraday::ConnectionFailed)
       end
     end
@@ -161,7 +161,7 @@ describe Elasticsearch::Transport::Transport::Base do
 
       it 'uses the option `retry_on_failure` value' do
         expect {
-          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+          client.transport.perform_request('GET', '/info', {}, nil, retry_on_failure: 5)
         }.to raise_exception(Faraday::ConnectionFailed)
       end
     end
@@ -201,7 +201,7 @@ describe Elasticsearch::Transport::Transport::Base do
 
       it 'uses the option `retry_on_failure` value' do
         expect {
-          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+          client.transport.perform_request('GET', '/info', {}, nil, retry_on_failure: 5)
         }.to raise_exception(Faraday::ConnectionFailed)
       end
     end
@@ -240,7 +240,7 @@ describe Elasticsearch::Transport::Transport::Base do
 
       it 'uses the option `retry_on_failure` value' do
         expect {
-          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+          client.transport.perform_request('GET', '/info', {}, nil, retry_on_failure: 5)
         }.to raise_exception(Faraday::ConnectionFailed)
       end
     end

--- a/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
@@ -1,0 +1,248 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'spec_helper'
+
+describe Elasticsearch::Transport::Transport::Base do
+
+  context 'when a host is printed in a logged message' do
+
+    shared_examples_for 'a redacted string' do
+
+      let(:client) do
+        Elasticsearch::Transport::Client.new(arguments)
+      end
+
+      let(:logger) do
+        double('logger', error?: true, error: '')
+      end
+
+      it 'does not include the password in the logged string' do
+        expect(logger).not_to receive(:error).with(/secret_password/)
+        expect {
+          client.cluster.stats
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+
+      it 'replaces the password with the string \'REDACTED\'' do
+        expect(logger).to receive(:error).with(/REDACTED/)
+        expect {
+          client.cluster.stats
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+
+    context 'when the user and password are provided as separate arguments' do
+
+      let(:arguments) do
+        { hosts: 'fake',
+          logger: logger,
+          password: 'secret_password',
+          user: 'test' }
+      end
+
+      it_behaves_like 'a redacted string'
+    end
+
+    context 'when the user and password are provided in the string URI' do
+
+      let(:arguments) do
+        { hosts: 'http://test:secret_password@fake.com',
+          logger: logger }
+      end
+
+      it_behaves_like 'a redacted string'
+    end
+
+    context 'when the user and password are provided in the URI object' do
+
+      let(:arguments) do
+        { hosts: URI.parse('http://test:secret_password@fake.com'),
+          logger: logger }
+      end
+
+      it_behaves_like 'a redacted string'
+    end
+  end
+
+  context 'when reload_on_failure is true and and hosts are unreachable' do
+
+    let(:client) do
+      Elasticsearch::Transport::Client.new(arguments)
+    end
+
+    let(:arguments) do
+      {
+          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          reload_on_failure: true,
+          sniffer_timeout: 5
+      }
+    end
+
+    it 'raises an exception' do
+      expect {
+        client.info
+      }.to raise_exception(Faraday::ConnectionFailed)
+    end
+  end
+
+  context 'when the client has `retry_on_failure` set to an integer' do
+
+    let(:client) do
+      Elasticsearch::Transport::Client.new(arguments)
+    end
+
+    let(:arguments) do
+      {
+          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          retry_on_failure: 2
+      }
+    end
+
+    context 'when `perform_request` is called without a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(3).times.and_call_original
+      end
+
+      it 'uses the client `retry_on_failure` value' do
+        expect {
+          client.transport.perform_request('GET', '/info')
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+
+    context 'when `perform_request` is called with a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
+      end
+
+      it 'uses the option `retry_on_failure` value' do
+        expect {
+          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+  end
+
+  context 'when the client has `retry_on_failure` set to true' do
+
+    let(:client) do
+      Elasticsearch::Transport::Client.new(arguments)
+    end
+
+    let(:arguments) do
+      {
+          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          retry_on_failure: true
+      }
+    end
+
+    context 'when `perform_request` is called without a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(4).times.and_call_original
+      end
+
+      it 'uses the default `MAX_RETRIES` value' do
+        expect {
+          client.transport.perform_request('GET', '/info')
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+
+    context 'when `perform_request` is called with a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
+      end
+
+      it 'uses the option `retry_on_failure` value' do
+        expect {
+          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+  end
+
+  context 'when the client has `retry_on_failure` set to false' do
+
+    let(:client) do
+      Elasticsearch::Transport::Client.new(arguments)
+    end
+
+    let(:arguments) do
+      {
+          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          retry_on_failure: false
+      }
+    end
+
+    context 'when `perform_request` is called without a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).once.and_call_original
+      end
+
+      it 'does not retry' do
+        expect {
+          client.transport.perform_request('GET', '/info')
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+
+    context 'when `perform_request` is called with a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
+      end
+
+      it 'uses the option `retry_on_failure` value' do
+        expect {
+          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+  end
+
+  context 'when the client has no `retry_on_failure` set' do
+
+    let(:client) do
+      Elasticsearch::Transport::Client.new(arguments)
+    end
+
+    let(:arguments) do
+      {
+          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+      }
+    end
+
+    context 'when `perform_request` is called without a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(1).times.and_call_original
+      end
+
+      it 'does not retry' do
+        expect {
+          client.transport.perform_request('GET', '/info')
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+
+    context 'when `perform_request` is called with a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
+      end
+
+      it 'uses the option `retry_on_failure` value' do
+        expect {
+          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cherry-pick https://github.com/elastic/elasticsearch-ruby/pull/696 that addresses https://github.com/elastic/elasticsearch-ruby/issues/695. Changes are applied to version 5.0.5 used by our apps. https://github.com/elastic/elasticsearch-ruby/issues/695 have not yet been released and will be available in  `elasticsearch-ruby` v8.

These changes are required to fix https://github.com/Leadfeeder/issue-tracker/issues/10163